### PR TITLE
feat: implement better subgroup placement with SchallCircuitGroup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - [item=compaktcircuit-processor] Keep subgroup circuit-network when SchallCircuitGroup is installed.
+    - [item=compaktcircuit-processor_1x1] Keep subgroup circuit-network when SchallCircuitGroup is installed.
+    - [item=compaktcircuit-input] Move to subgroup circuit-combinator when SchallCircuitGroup is installed.
+    - [item=compaktcircuit-internal_iopoint] Move to subgroup circuit-input when SchallCircuitGroup is installed.
+    - [item=compaktcircuit-display] Move to subgroup circuit-visual when SchallCircuitGroup is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,2 @@
+-- Better subgroup placement with SchallCircuitGroup
+require("data-updates.schall-circuit-group")

--- a/data-updates/schall-circuit-group.lua
+++ b/data-updates/schall-circuit-group.lua
@@ -1,0 +1,8 @@
+if mods["SchallCircuitGroup"] then
+  data.raw.item["compaktcircuit-processor"].subgroup = "circuit-network"
+  data.raw.item["compaktcircuit-processor_1x1"].subgroup = "circuit-network"
+
+  data.raw.item["compaktcircuit-input"].subgroup = "circuit-combinator"
+  data.raw.item["compaktcircuit-internal_iopoint"].subgroup = "circuit-input"
+  data.raw.item["compaktcircuit-display"].subgroup = "circuit-visual"
+end


### PR DESCRIPTION
- [item=compaktcircuit-processor] Keep subgroup circuit-network when SchallCircuitGroup is installed.
- [item=compaktcircuit-processor_1x1] Keep subgroup circuit-network when SchallCircuitGroup is installed.
- [item=compaktcircuit-input] Move to subgroup circuit-combinator when SchallCircuitGroup is installed.
- [item=compaktcircuit-internal_iopoint] Move to subgroup circuit-input when SchallCircuitGroup is installed.
- [item=compaktcircuit-display] Move to subgroup circuit-visual when SchallCircuitGroup is installed.