### PR TITLE
feat: add recipe and tech overhaul setting to simplify compact processor recipes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,3 +7,5 @@ Date: ????
     - [item=compaktcircuit-input] Move to subgroup circuit-combinator when SchallCircuitGroup is installed.
     - [item=compaktcircuit-internal_iopoint] Move to subgroup circuit-input when SchallCircuitGroup is installed.
     - [item=compaktcircuit-display] Move to subgroup circuit-visual when SchallCircuitGroup is installed.
+  Features:
+    - Add setting to remove [item=advanced-circuit] and [item=processing-unit] from compact processor recipes, making them easier to produce in the early game. This change will also move the compact circuits technology directly after circuit networks in the tech tree and makes it cheaper to research.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,2 +1,5 @@
 -- Better subgroup placement with SchallCircuitGroup
 require("data-updates.schall-circuit-group")
+
+-- Remove advanced circuits and processing units from recipes, but keep their total value by adding more basic components and make the tech cheaper and earlier.
+require("data-updates.recipe-tech-overhaul")

--- a/data-updates/recipe-tech-overhaul.lua
+++ b/data-updates/recipe-tech-overhaul.lua
@@ -1,11 +1,9 @@
 if settings.startup["compaktcircuittweaks-recipe-tech-overhaul"].value then
   for _, recipe in pairs({"compaktcircuit-processor", "compaktcircuit-processor_1x1"}) do
-    local ingredient = nil
     local replacement_amount = 0
-
     for _, ingredient_to_remove in pairs({"advanced-circuit", "processing-unit"}) do
       for i = 1, #data.raw.recipe[recipe].ingredients do
-        ingredient = data.raw.recipe[recipe].ingredients[i]
+        local ingredient = data.raw.recipe[recipe].ingredients[i]
         if ingredient.name == ingredient_to_remove then
           replacement_amount = replacement_amount + ingredient.amount
           table.remove(data.raw.recipe[recipe].ingredients, i)
@@ -15,7 +13,7 @@ if settings.startup["compaktcircuittweaks-recipe-tech-overhaul"].value then
     end
 
     for i = 1, #data.raw.recipe[recipe].ingredients do
-      ingredient = data.raw.recipe[recipe].ingredients[i]
+      local ingredient = data.raw.recipe[recipe].ingredients[i]
       if ingredient.name == "electronic-circuit" then
         data.raw.recipe[recipe].ingredients[i].amount = ingredient.amount + replacement_amount
         break
@@ -25,7 +23,7 @@ if settings.startup["compaktcircuittweaks-recipe-tech-overhaul"].value then
 
   data.raw.technology["compaktcircuit-tech"].prerequisites = {"circuit-network"}
   for i = 1, #data.raw.technology["compaktcircuit-tech"].unit.ingredients do
-    ingredient = data.raw.technology["compaktcircuit-tech"].unit.ingredients[i]
+    local ingredient = data.raw.technology["compaktcircuit-tech"].unit.ingredients[i]
     if ingredient[1] == "chemical-science-pack" then
       table.remove(data.raw.technology["compaktcircuit-tech"].unit.ingredients, i)
       break

--- a/data-updates/recipe-tech-overhaul.lua
+++ b/data-updates/recipe-tech-overhaul.lua
@@ -1,0 +1,34 @@
+if settings.startup["compaktcircuittweaks-recipe-tech-overhaul"].value then
+  for _, recipe in pairs({"compaktcircuit-processor", "compaktcircuit-processor_1x1"}) do
+    local ingredient = nil
+    local replacement_amount = 0
+
+    for _, ingredient_to_remove in pairs({"advanced-circuit", "processing-unit"}) do
+      for i = 1, #data.raw.recipe[recipe].ingredients do
+        ingredient = data.raw.recipe[recipe].ingredients[i]
+        if ingredient.name == ingredient_to_remove then
+          replacement_amount = replacement_amount + ingredient.amount
+          table.remove(data.raw.recipe[recipe].ingredients, i)
+          break
+        end
+      end
+    end
+
+    for i = 1, #data.raw.recipe[recipe].ingredients do
+      ingredient = data.raw.recipe[recipe].ingredients[i]
+      if ingredient.name == "electronic-circuit" then
+        data.raw.recipe[recipe].ingredients[i].amount = ingredient.amount + replacement_amount
+        break
+      end
+    end
+  end
+
+  data.raw.technology["compaktcircuit-tech"].prerequisites = {"circuit-network"}
+  for i = 1, #data.raw.technology["compaktcircuit-tech"].unit.ingredients do
+    ingredient = data.raw.technology["compaktcircuit-tech"].unit.ingredients[i]
+    if ingredient[1] == "chemical-science-pack" then
+      table.remove(data.raw.technology["compaktcircuit-tech"].unit.ingredients, i)
+      break
+    end
+  end
+end

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -1,0 +1,5 @@
+[mod-setting-name]
+compaktcircuittweaks-recipe-tech-overhaul=Remove [item=advanced-circuit] and [item=processing-unit] from compact processor recipes
+
+[mod-setting-description]
+compaktcircuittweaks-recipe-tech-overhaul=If enabled, compact processor recipes will no longer require [item=advanced-circuit] and [item=processing-unit]. Instead, they will require more basic components, making them easier to produce in the early game.\n\nThis change will also move the compact circuits technology directly after circuit networks in the tech tree and makes it cheaper to research.

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,9 @@
+data:extend({
+  {
+    type = "bool-setting",
+    name = "compaktcircuittweaks-recipe-tech-overhaul",
+    setting_type = "startup",
+    default_value = false,
+    order = "aaa",
+  },
+})


### PR DESCRIPTION
- Add setting to remove [item=advanced-circuit] and [item=processing-unit] from compact processor recipes, making them easier to produce in the early game. This change will also move the compact circuits technology directly after circuit networks in the tech tree and makes it cheaper to research.